### PR TITLE
Add a button to the icon viewer to reset the camera

### DIFF
--- a/crates/suitcase/src/rendering/orbit_camera.rs
+++ b/crates/suitcase/src/rendering/orbit_camera.rs
@@ -35,4 +35,10 @@ impl OrbitCamera {
             vec3(0.0, 1.0, 0.0),
         )
     }
+
+    pub fn reset_view(&mut self) {
+        self.yaw = 0.0;
+        self.pitch = 0.0;
+        self.distance = 10.0;
+    }
 }

--- a/crates/suitcase/src/tabs/icn_viewer.rs
+++ b/crates/suitcase/src/tabs/icn_viewer.rs
@@ -191,6 +191,10 @@ impl ICNViewer {
                     }
                 }
 
+                if ui.button("Reset View").clicked() {
+                    self.camera.reset_view();
+                }
+
                 ui.checkbox(&mut self.dark_mode, "Dark Mode");
             });
 


### PR DESCRIPTION
This simple button helps reset the camera to the front of the icon. This is useful when troubleshooting icon orientation or when the icon has lots of symmetry.